### PR TITLE
changing FileSystemTypeInfo members to signed short since a -1 value is used

### DIFF
--- a/src/MountPointAttr.h
+++ b/src/MountPointAttr.h
@@ -43,6 +43,7 @@ extern "C" {
 #include <mntent.h>
 #include <string.h>
 #include <stdio.h>
+#include <limits.h>
 }
 
 #include <string>
@@ -239,7 +240,7 @@ namespace FastGlobalFileStatus {
 
     const int BASE_FS_SPEED = 1;
     const int BASE_FS_SCALABILITY = 1;
-    const int INDIRECTION = -1;
+    const unsigned short INDIRECTION = USHRT_MAX;
 
 
     /**


### PR DESCRIPTION
The speed and scalability members of the FileSystemTypeInfo were being defined as "unsigned short", but one of the values passed was "INDIRECTION = -1". This PR resolves this compilation error:

libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I.. -I.. -g -O2 -MT libmpattr_la-MountPointAttr.lo -MD -MP -MF .deps/libmpattr_la-MountPointAttr.Tpo -c MountPointAttr.C  -fPIC -DPIC -o .libs/libmpattr_la-MountPointAttr.o
MountPointAttr.C:133:1: error: narrowing conversion of '-1' from 'int' to 'short unsigned int' inside { } [-Wnarrowing]
 };
 ^
MountPointAttr.C:133:1: error: narrowing conversion of '-1' from 'int' to 'short unsigned int' inside { } [-Wnarrowing]
